### PR TITLE
BSC-2227 	  mininet tcpall result not consistent 	

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -504,11 +504,11 @@ class Mininet( object ):
         # message to see if this is indeed a connectivity 
         # issue or something else. E.g., ENOBUFS
         if "CONN TIMEOUT" in result:
-            return "C"
+            return "c"
         if "CONN ERROR" in result:
             return "C"
         if "XFER TIMEOUT" in result:
-            return "X"
+            return "x"
         if "XFER ERROR" in result:
             return "X"
         if "OK" in result:
@@ -543,7 +543,13 @@ class Mininet( object ):
             for dest in hosts:
                 if node != dest:
                     total += 1
-                    srvResult = dest.sendCmd("mn-tcptest-srv.py %f %d" % (timeout, self.curTcpPort))
+
+                    #
+                    # Use a larger timeout for the server, as we do not want
+                    # the server to timeout before the client gets a chance
+                    # send the packets.
+                    #
+                    srvResult = dest.sendCmd("mn-tcptest-srv.py %f %d" % (timeout * 10, self.curTcpPort))
                     dest.waitOutput(pattern = self._listenRegex)
                     cliResult = node.cmd( 'mn-tcptest-cli.py %f %s %d' % (timeout, dest.IP(), self.curTcpPort) )
                     sleep(0.01)


### PR DESCRIPTION
BSC-2227 mininet tcpall result not consistent

Packets timeout because of short time out used in both server and client. Actually, we need to use a short timeout only at the client side. Otherwise, there is a chance server times out even before the client times out (or has a chance to send packets) due to linux scheduling.

We abort the server anyways, after the client times out (or completes) the transaction. Also have return code specific for "connect timeout" and "connect error" such as (connection refused).

addrspace/BasicTest.py now passes consistently
