### PR TITLE
Increase tcpall default timeout from 0.3 to 0.5 seconds

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -516,7 +516,7 @@ class Mininet( object ):
         return "?"
         
     _listenRegex = re.compile("LISTENING")
-    def tcptest( self, hosts=None, timeout=0.3 ):
+    def tcptest( self, hosts=None, timeout=0.5 ):
         """TCP reachability test
            hosts: list of hosts. 
            timeout: TCP connection and read timeout in seconds


### PR DESCRIPTION
Need to verify if this causes address-space tests to not to fail intermittently. Even 0.1 seconds is good enough in my local setup, but for some unknown reason, (different load ?), some tests timeout.
