### PR TITLE
cli: don't read/write readline history more than once

### DIFF
--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -38,6 +38,25 @@ from mininet.log import info, output, error
 from mininet.term import makeTerms, runX11
 from mininet.util import quietRun, isShellBuiltin, dumpNodeConnections
 
+has_setup_readline = False
+def setup_readline():
+    "Set up history if readline is available"
+
+    # Only set up readline once to prevent multiplying the history file
+    if has_setup_readline:
+        return
+    has_setup_readline = True
+
+    try:
+        import readline
+    except ImportError:
+        pass
+    else:
+        history_path = os.path.expanduser('~/.mininet_history')
+        if os.path.isfile(history_path):
+            readline.read_history_file(history_path)
+        atexit.register(lambda: readline.write_history_file(history_path))
+
 class CLI( Cmd ):
     "Simple command-line interface to talk to nodes."
 
@@ -55,20 +74,12 @@ class CLI( Cmd ):
         Cmd.__init__( self )
         info( '*** Starting CLI:\n' )
 
-        # Setup history if readline is available
-        try:
-            import readline
-        except ImportError:
-            pass
-        else:
-            history_path = os.path.expanduser('~/.mininet_history')
-            if os.path.isfile(history_path):
-                readline.read_history_file(history_path)
-            atexit.register(lambda: readline.write_history_file(history_path))
-
         if self.inputFile:
             self.do_source( self.inputFile )
             return
+
+        setup_readline()
+
         while True:
             try:
                 # Make sure no nodes are still waiting


### PR DESCRIPTION
Previously, when creating multiple CLI objects, each one would append the
~/.mininet_history file to readline's internal list. When writing the file back
it would be duplicated for each CLI object created. So, over a few mininet runs
the history file would grow exponentially.

This change moves the readline setup code out of the CLI constructor and adds a
global flag to prevent it from being executed more than once.
